### PR TITLE
Allow /target to target non-enemy units

### DIFF
--- a/Conditionals.lua
+++ b/Conditionals.lua
@@ -391,6 +391,7 @@ function CleveRoids.ValidateAura(unit, args, isbuff)
     while true do
         if isPlayer then
             texture, stacks, spellID, remaining = CleveRoids.GetPlayerAura(i, isbuff)
+--            print ("Found spell with texture ", texture, " stacks" , stacks, "remaining ", remaining)            
         else
             if isbuff then
                 texture, stacks, spellID = UnitBuff(unit, i)
@@ -398,15 +399,15 @@ function CleveRoids.ValidateAura(unit, args, isbuff)
                 texture, stacks, _, spellID = UnitDebuff(unit, i)
             end
         end
-
+--        print ("Found spell with texture ", texture, " stacks" , stacks, "remaining ", remaining)            
         if (CleveRoids.hasSuperwow and not spellID) or not texture then break end
         if (CleveRoids.hasSuperwow and args.name == SpellInfo(spellID))
             or (not CleveRoids.hasSuperwow and texture == CleveRoids.auraTextures[args.name])
         then
+            
             found = true
             break
         end
-
         i = i + 1
     end
 

--- a/Conditionals.lua
+++ b/Conditionals.lua
@@ -43,6 +43,7 @@ end
 -- returns: Whether or not the given target can either be attacked or supported, depending on help
 function CleveRoids.CheckHelp(target, help)
     if help == nil then return true end
+    if target == nil then return false end
     if help then
         return UnitCanAssist("player", target)
     else

--- a/Console.lua
+++ b/Console.lua
@@ -82,9 +82,11 @@ SlashCmdList.CAST = CleveRoids.CAST_SlashCmd
 
 CleveRoids.Hooks.TARGET_SlashCmd = SlashCmdList.TARGET
 CleveRoids.TARGET_SlashCmd = function(msg)
-    msg = CleveRoids.Trim(msg)
-    if CleveRoids.DoTarget(msg) then
-        return
+    tmsg = CleveRoids.Trim(msg)
+    if CleveRoids.DoTarget(tmsg) then
+        if UnitExists("target") then
+            return
+        end
     end
     CleveRoids.Hooks.TARGET_SlashCmd(msg)
 end

--- a/Console.lua
+++ b/Console.lua
@@ -9,6 +9,30 @@ SLASH_PETATTACK1 = "/petattack"
 
 SlashCmdList.PETATTACK = function(msg) CleveRoids.DoPetAttack(msg); end
 
+SLASH_FEEDPET1 = "/feedpet"
+
+SlashCmdList.FEEDPET = function(msg) CleveRoids.FeedPet(msg); end
+
+SLASH_PETPASSIVE1 = "/petpassive"
+
+SlashCmdList.PETPASSIVE = function(msg) CleveRoids.DoSimpleAction(PetPassiveMode, msg); end
+
+SLASH_PETDEFENSIVE1 = "/petdefensive"
+
+SlashCmdList.PETDEFENSIVE = function(msg) CleveRoids.DoSimpleAction(PetDefensiveMode, msg); end
+
+SLASH_PETAGGRESSIVE1 = "/petaggressive"
+
+SlashCmdList.PETAGGRESSIVE = function(msg) CleveRoids.DoSimpleAction(PetAggressiveMode, msg); end
+
+SLASH_PETFOLLOW1 = "/petfollow"
+
+SlashCmdList.PETFOLLOW = function(msg) CleveRoids.DoSimpleAction(PetFollow, msg); end
+
+SLASH_PETWAIT1 = "/petwait"
+
+SlashCmdList.PETWAIT = function(msg) CleveRoids.DoSimpleAction(PetWait, msg); end
+
 SLASH_RELOAD1 = "/rl"
 
 SlashCmdList.RELOAD = function() ReloadUI(); end

--- a/Core.lua
+++ b/Core.lua
@@ -788,6 +788,25 @@ function CleveRoids.DoPetAttack(msg)
     return handled
 end
 
+
+-- Attempts to call a function that has no arguments or target if conditionals are met
+-- msg: The raw conditionals string intercepted from a command
+function CleveRoids.DoSimpleAction(action, msg)
+
+    local handled = false
+    for k, v in pairs(CleveRoids.splitStringIgnoringQuotes(msg)) do
+        CleveRoids.Print("Conditional: ", v)
+        if CleveRoids.DoWithConditionals(v, action, CleveRoids.FixEmptyTarget, false, action) then
+            handled = true
+            break
+        end
+    end
+    if handled == nil then
+        action()
+    end
+    return handled
+end
+
 -- Attempts to use or equip an item from the player's inventory by a  set of conditionals
 -- Also checks if a condition is a spell so that you can mix item and spell use
 -- msg: The raw message intercepted from a /use or /equip command
@@ -825,6 +844,21 @@ function CleveRoids.DoUse(msg)
         if handled then break end
     end
     return handled
+end
+
+
+function CleveRoids.FeedPet(msg)
+    CleveRoids.DoCast("Feed Pet")
+    CleveRoids.PickupItem(msg)
+    ClearCursor()
+end
+
+function CleveRoids.PickupItem(msg) 
+    local item = CleveRoids.GetItem(msg)
+    if item.bagID then
+        CleveRoids.GetNextBagSlotForUse(item, msg)
+        PickupContainerItem(item.bagID, item.slot)
+    end
 end
 
 function CleveRoids.EquipBagItem(msg, offhand)

--- a/Init.lua
+++ b/Init.lua
@@ -93,6 +93,11 @@ CleveRoids.spamConditions = {
 CleveRoids.auraTextures = {
     [CleveRoids.Localized.Spells["Stealth"]]    = "Interface\\Icons\\Ability_Stealth",
     [CleveRoids.Localized.Spells["Prowl"]]      = "Interface\\Icons\\Ability_Ambush",
+    ["Seal of Wisdom"] = "Interface\\Icons\\Spell_Holy_RighteousnessAura",
+    ["Seal of the Crusader"] = "Interface\\Icons\\Spell_Holy_HolySmite",
+    ["Seal of Light"] = "Interface\\Icons\\Spell_Holy_HealingAura",
+    ["Seal of the Justice"] = "Interface\\Icons\\Spell_Holy_SealOfWrath",
+    ["Seal of Righteousness"] = "Interface\\Icons\\Ability_ThunderBolt",
     [CleveRoids.Localized.Spells["Shadowform"]] = "Interface\\Icons\\Spell_Shadow_Shadowform",
 }
 


### PR DESCRIPTION
Cleveroid overrides the default /target command and replaces it with its own but in doing so it removes the ability to use this command to target anything that isn't an enemy.   This change checks to see if cleveroid's function finds a target and if not, calls the built in command as a fallback restoring the ability to target non-enemies. 