### PR TITLE
fix: validate known not working as intended

### DIFF
--- a/Conditionals.lua
+++ b/Conditionals.lua
@@ -214,12 +214,12 @@ function CleveRoids.ValidateKnown(args)
         talent = CleveRoids.GetTalent(args.name)
     end
 
-    if talent == 0 or rank == 0 then
-        return false
-    end
     if not spell and not talent then return false end
     local rank = spell and string.gsub(spell.rank, "Rank ", "") or talent
 
+    if talent == 0 or rank == 0 then
+        return false
+    end
     if rank and not args.amount and not args.operator then
         return true
     elseif args.amount and CleveRoids.operators[args.operator] then

--- a/Conditionals.lua
+++ b/Conditionals.lua
@@ -214,6 +214,9 @@ function CleveRoids.ValidateKnown(args)
         talent = CleveRoids.GetTalent(args.name)
     end
 
+    if talent == 0 or rank == 0 then
+        return false
+    end
     if not spell and not talent then return false end
     local rank = spell and string.gsub(spell.rank, "Rank ", "") or talent
 


### PR DESCRIPTION
I had a macro as simple as this and the tooltip was not loading properly.

#showtooltip
/cast [known] Blade Flurry
/cast [known] Smoke Bomb

