### PR TITLE
add mycasting and nomycasting Conditionals.lua

### DIFF
--- a/Conditionals.lua
+++ b/Conditionals.lua
@@ -626,6 +626,21 @@ CleveRoids.Keywords = {
             return not CleveRoids.CheckSpellCast(conditionals.target, spell)
         end)
     end,
+	
+    mycasting = function(conditionals)
+        if type(conditionals.mycasting) ~= "table" then return CleveRoids.CheckSpellCast("player", "") end
+        return Or(conditionals.mycasting, function (spell)
+            return CleveRoids.CheckSpellCast("player", spell)
+        end)
+    end,
+
+    nomycasting = function(conditionals) 
+        if type(conditionals.nomycasting) ~= "table" then return not CleveRoids.CheckSpellCast("player", "") end
+        return And(conditionals.nomycasting, function (spell)
+            print('here', spell, CleveRoids.CheckSpellCast("player", spell))
+            return not CleveRoids.CheckSpellCast("player", spell)
+        end)
+    end,
 
     zone = function(conditionals)
         local zone = GetRealZoneText()


### PR DESCRIPTION
This fixes bug #39. By adding a check to see if the player is casting a spell you can stop the queueing that wow naturally wants to do. This slows down casting a bit, but lets you make pretty amazing macros.